### PR TITLE
Added --sort option support to bossquery.py, taking a SQL formatted s…

### DIFF
--- a/bin/bossquery
+++ b/bin/bossquery
@@ -33,7 +33,7 @@ def main():
     parser.add_argument('--no-clobber', action = 'store_true',
         help = 'Do not overwrite any existing save file with the same name.')
     parser.add_argument('--sort', type = str, default = None, metavar = 'SORT',
-        help = 'Sort; follows SQL syntaxt, columns listed in order of sort priority, DESC optionally specified to reverse order.')
+        help = 'Sort; follows SQL syntax, columns listed in order of sort priority, DESC optionally specified to reverse order.')
     args = parser.parse_args()
 
     try:

--- a/bin/bossquery
+++ b/bin/bossquery
@@ -32,11 +32,13 @@ def main():
         help = 'Save results to the specified file, whose extension determines the format.')
     parser.add_argument('--no-clobber', action = 'store_true',
         help = 'Do not overwrite any existing save file with the same name.')
+    parser.add_argument('--sort', type = str, default = None, metavar = 'SORT',
+        help = 'Sort; follows SQL syntaxt, columns listed in order of sort priority, DESC optionally specified to reverse order.')
     args = parser.parse_args()
 
     try:
         meta_db = bossdata.meta.Database(lite = not args.full)
-        table = meta_db.select_all(args.what,args.where,max_rows = args.max_rows)
+        table = meta_db.select_all(args.what,args.where,args.sort,max_rows = args.max_rows)
     except (RuntimeError,ValueError) as e:
         print(e)
         return -1

--- a/bin/scripts.rst
+++ b/bin/scripts.rst
@@ -30,9 +30,23 @@ bossquery
 
 Query the meta data for BOSS observations. For example::
 
-    bossquery --what PLATE,MJD,FIBER,PLUG_RA,PLUG_DEC,Z --where 'OBJTYPE="QSO"' --save qso.dat
+    bossquery --what PLATE,MJD,FIBER,PLUG_RA,PLUG_DEC,Z --where 'OBJTYPE="QSO"' --sort Z --save qso.dat
 
-The save option supports `many different output formats <http://astropy.readthedocs.org/en/latest/io/unified.html#built-in-table-readers-writers>`_ that are automatically selected based on the file extension.  In addition, this program automatically maps the `.dat` and `.txt` extensions to the `ascii` format.
+The `--save` option supports `many different output formats <http://astropy.readthedocs.org/en/latest/io/unified.html#built-in-table-readers-writers>`_ that are automatically selected based on the file extension.  In addition, this program automatically maps the `.dat` and `.txt` extensions to the `ascii` format.
+
+The `--what`, `--where` and `--sort` options all use SQL syntax (these are in fact substituted into a SQL string).
+
+* `--what` takes a comma separated list of column names (like SQL SELECT) and defaults to PLATE,MJD,FIBER::
+
+    --what PLATE,MJD,FIBER,PLUG_RA,PLUG_DEC,Z
+    
+* `--where` takes a SQL 'WHERE' string::
+
+    --where '(OBJYPE="QSO" and Z > 0.1) or CLASS="QSO"'
+
+* `--sort` takes a list of columns with optional DESC keywork following columns to reverse their order (a la SQL ORDER BY)::
+
+    --sort 'CLASS, Z DESC'
 
 This command uses an sqlite3 database of metadata that will be created if necessary. By default, the "lite" version database will be used, which provides faster queries and a smaller database file.  However, the full `spAll data model <http://dr12.sdss3.org/datamodel/files/BOSS_SPECTRO_REDUX/RUN2D/spAll.html>`_ is also available with the `--full` option (resulting in slower queries and a larger database file).  The "lite" and "full" databases are separate files based on different downloads. Once either has been created the first time, it will be immediately available for future queries.  Note that it can take a while to create the initial database file: allow about 30 minutes for either version. Once the database has been created, you can safely delete the downloaded source file if you are short on disk space.
 

--- a/bossdata/meta.py
+++ b/bossdata/meta.py
@@ -6,7 +6,6 @@
 
 from __future__ import division, print_function
 
-import sys
 import os
 import os.path
 import gzip
@@ -16,7 +15,7 @@ import numpy as np
 import astropy.table
 import fitsio
 
-from progressbar import ProgressBar, Percentage, Bar, FormatLabel
+from progressbar import ProgressBar, Percentage, Bar
 
 import bossdata.path
 import bossdata.remote
@@ -164,6 +163,7 @@ def create_meta_full(sp_all_path, db_path, verbose=True):
             a FITS file conforming to the spAll data model.
         db_path(str): Local path where the corresponding sqlite3 database will be written.
     """
+
     if verbose:
         print('Initializing the full database...')
 

--- a/bossdata/meta.py
+++ b/bossdata/meta.py
@@ -168,6 +168,8 @@ def create_meta_lite(sp_all_path, db_path, verbose=True):
                                              guess=False)
         connection.commit()
         connection.close()
+        if verbose:
+            progress_bar.finish()
 
 def create_meta_full(sp_all_path, db_path, verbose=True):
     """Create the "full" meta database from a locally mirrored spAll file.


### PR DESCRIPTION
…ort string

Added --sort option support to meta.py Database.select_all method

Altered meta.py create_meta_lite method to parse only first 100 lines using `astropy` methods, then read in remainder using numpy.loadtxt (per dkirkby's comment down-thread)

Updated bin/scripts.rst with additional information about command line args to bossquery
