### PR TITLE
Add support for BOSS quasar catalogs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -49,6 +49,8 @@ articles, and such.  We use the `sphinx napolean extension <http://sphinx-doc.or
  * methods ``:meth:`bosdata.module.Class.method```
  * functions ``:func:`bossdata.module.func```
 
+* You can override the default link text by changing ``:role:`target``` to ``:role:`text <target>```.
+
 Submit Feedback
 ~~~~~~~~~~~~~~~
 

--- a/bin/bossquery
+++ b/bin/bossquery
@@ -34,10 +34,12 @@ def main():
         help = 'Do not overwrite any existing save file with the same name.')
     parser.add_argument('--sort', type = str, default = None, metavar = 'SORT',
         help = 'Sort; follows SQL syntax, columns listed in order of sort priority, DESC optionally specified to reverse order.')
+    parser.add_argument('--quasar-catalog', action='store_true',
+        help='Query quasar catalog instead of spAll.')
     args = parser.parse_args()
 
     try:
-        meta_db = bossdata.meta.Database(lite=(not args.full))
+        meta_db = bossdata.meta.Database(lite=(not args.full), quasar_catalog=args.quasar_catalog)
         table = meta_db.select_all(args.what, args.where, args.sort, max_rows=args.max_rows)
     except (RuntimeError,ValueError) as e:
         print(e)

--- a/bin/bossquery
+++ b/bin/bossquery
@@ -36,7 +36,7 @@ def main():
         help = 'Sort; follows SQL syntax, columns listed in order of sort priority, DESC optionally specified to reverse order.')
     parser.add_argument('--quasar-catalog', action='store_true',
         help='Query quasar catalog instead of spAll.')
-    parser.add_argument('--quasar-catalog-name', type=str, default=None,
+    parser.add_argument('--quasar-catalog-name', type=str, default=bossdata.path.Finder.default_quasar_catalog_name,
         help='Use the specified BOSS quasar catalog name.')
     args = parser.parse_args()
 

--- a/bin/bossquery
+++ b/bin/bossquery
@@ -37,8 +37,8 @@ def main():
     args = parser.parse_args()
 
     try:
-        meta_db = bossdata.meta.Database(lite = not args.full)
-        table = meta_db.select_all(args.what,args.where,args.sort,max_rows = args.max_rows)
+        meta_db = bossdata.meta.Database(lite=(not args.full))
+        table = meta_db.select_all(args.what, args.where, args.sort, max_rows=args.max_rows)
     except (RuntimeError,ValueError) as e:
         print(e)
         return -1
@@ -61,10 +61,10 @@ def main():
     if args.save:
         root,ext = os.path.splitext(args.save)
         if ext in ('.dat','.txt'):
-             table.write(args.save,format = 'ascii')
+             table.write(args.save, format='ascii')
         else:
             try:
-                table.write(args.save,overwrite = not args.no_clobber)
+                table.write(args.save, overwrite=(not args.no_clobber))
                 if args.verbose:
                     print('Results saved to {}.'.format(args.save))
             except Exception,e:

--- a/bin/bossquery
+++ b/bin/bossquery
@@ -40,8 +40,12 @@ def main():
         help='Use the specified BOSS quasar catalog name.')
     args = parser.parse_args()
 
+    # Use the "lite" version of spAll unless --full is requested.
+    # There is no "lite" version of the quasar catalog.
+    use_lite = not (args.full or args.quasar_catalog)
+
     try:
-        meta_db = bossdata.meta.Database(lite=(not (args.full or args.quasar_catalog)), quasar_catalog=args.quasar_catalog,
+        meta_db = bossdata.meta.Database(lite=use_lite, quasar_catalog=args.quasar_catalog,
             quasar_catalog_name=args.quasar_catalog_name)
         table = meta_db.select_all(args.what, args.where, args.sort, max_rows=args.max_rows)
     except (RuntimeError,ValueError) as e:
@@ -49,8 +53,8 @@ def main():
         return -1
 
     if args.verbose:
-        if not args.full and not meta_db.lite:
-            print("Using --full database as lite files were not available.")
+        if use_lite and not meta_db.lite:
+            print('Using the --full database since it is already downloaded.')
         print('Database contains {:d} rows.'.format(meta_db.num_rows))
 
     if table is None:

--- a/bin/bossquery
+++ b/bin/bossquery
@@ -36,10 +36,13 @@ def main():
         help = 'Sort; follows SQL syntax, columns listed in order of sort priority, DESC optionally specified to reverse order.')
     parser.add_argument('--quasar-catalog', action='store_true',
         help='Query quasar catalog instead of spAll.')
+    parser.add_argument('--quasar-catalog-name', type=str, default=None,
+        help='Use the specified BOSS quasar catalog name.')
     args = parser.parse_args()
 
     try:
-        meta_db = bossdata.meta.Database(lite=(not args.full), quasar_catalog=args.quasar_catalog)
+        meta_db = bossdata.meta.Database(lite=(not (args.full or args.quasar_catalog)), quasar_catalog=args.quasar_catalog,
+            quasar_catalog_name=args.quasar_catalog_name)
         table = meta_db.select_all(args.what, args.where, args.sort, max_rows=args.max_rows)
     except (RuntimeError,ValueError) as e:
         print(e)

--- a/bin/scripts.rst
+++ b/bin/scripts.rst
@@ -58,6 +58,9 @@ In the case where a query is made without specifying `--full` but the lite datab
 
 Note that specifying `--full` will only (and always) use the full DB or catalog file.
 
+The `--quasar-catalog` option can be used to query the `BOSS quasar catalog <http://www.sdss.org/dr12/algorithms/boss-dr12-quasar-catalog/>`_ instead of spAll. By default, the current version of the catalog will be used; use the `--quasar-catalog-name` option to specify an earlier version.
+
+
 .. _bossfetch:
 
 bossfetch

--- a/bossdata/meta.py
+++ b/bossdata/meta.py
@@ -269,8 +269,8 @@ class Database(object):
             provides a subset of the most commonly accessed fields.
         quasar_catalog(bool): Initialize database using the BOSS quasar catalog instead of
             spAll.
-        quasar_catalog_name(str): The name of the BOSS quasar catalog or None to use the
-            default specified by :attr:`bossdata.path.Finder.default_quasar_catalog_name`.
+        quasar_catalog_name(str): The name of the BOSS quasar catalog to use, or use the
+            :attr:`default <bossdata.path.Finder.default_quasar_catalog_name>` if this is None.
     """
     def __init__(self, finder=None, mirror=None, lite=True, quasar_catalog=False,
                  quasar_catalog_name=None):

--- a/bossdata/meta.py
+++ b/bossdata/meta.py
@@ -11,6 +11,7 @@ import os.path
 import gzip
 import sqlite3
 import stat
+import re
 
 import numpy as np
 import astropy.table
@@ -381,7 +382,7 @@ class Database(object):
             return self.column_names, self.column_dtypes
 
         names, dtypes = [], []
-        for name in column_names.split(','):
+        for name in re.split('\s*,\s*',column_names.strip()):
             try:
                 index = self.column_names.index(name)
             except ValueError:
@@ -407,7 +408,7 @@ class Database(object):
             what(str): Comma separated list of column names to return or '*' to return
                 all columns.
             where(str): SQL selection clause or None for no filtering. Reserved column
-                names such as PRIMARY must be `escaped` in this clause.
+                names such as PRIMARY must be escaped with backticks in this clause.
 
         Raises:
             sqlite3.OperationalError: failed to execute query.
@@ -435,7 +436,7 @@ class Database(object):
             what(str): Comma separated list of column names to return or '*' to return all
                 columns.
             where(str): SQL selection clause or None for no filtering. Reserved column names
-                such as PRIMARY must be `escaped` in this clause.
+                such as PRIMARY must be escaped with backticks in this clause.
             max_rows(int): Maximum number of rows that will be returned.
 
         Returns:

--- a/bossdata/meta.py
+++ b/bossdata/meta.py
@@ -299,8 +299,8 @@ class Database(object):
             remote_paths = [finder.get_sp_all_path(lite=True),
                             finder.get_sp_all_path(lite=False)]
             local_paths = [mirror.local_path(path) for path in remote_paths]
-            db_paths = [Database.db_path_helper(local_paths[0], lite=True),
-                        Database.db_path_helper(local_paths[1], lite=False)]
+            db_paths = [Database._db_path_helper(local_paths[0], lite=True),
+                        Database._db_path_helper(local_paths[1], lite=False)]
             db_paths_exist = [os.path.isfile(path) for path in db_paths]
 
             db_path = None
@@ -465,7 +465,7 @@ class Database(object):
         return astropy.table.Table(rows=rows, names=names)
 
     @staticmethod
-    def db_path_helper(path=None, lite=True):
+    def _db_path_helper(path=None, lite=True):
         if lite:
             assert path.endswith('.dat.gz'), 'Expected .dat.gz extension for {}.'.format(
                 path)

--- a/bossdata/meta.py
+++ b/bossdata/meta.py
@@ -165,8 +165,8 @@ def create_meta_lite(sp_all_path, db_path, verbose=True):
         progress_bar.finish()
 
 
-def create_meta_full(sp_all_path, db_path, verbose=True):
-    """Create the "full" meta database from a locally mirrored spAll file.
+def create_meta_full(catalog_path, db_path, verbose=True):
+    """Create the "full" meta database from a locally mirrored catalog file.
 
     The created database renames FIBERID to FIBER and has a composite primary index on the
     (PLATE,MJD,FIBER) columns. Sub-array columns are also unrolled: see
@@ -178,7 +178,7 @@ def create_meta_full(sp_all_path, db_path, verbose=True):
     and you are unlikely to end up with an invalid database file.
 
     Args:
-        sp_all_path(str): Absolute local path of the "full" spAll file, which is expected to be
+        catalog_path(str): Absolute local path of the "full" catalog file, which is expected to be
             a FITS file conforming to the spAll data model.
         db_path(str): Local path where the corresponding sqlite3 database will be written.
     """
@@ -190,7 +190,7 @@ def create_meta_full(sp_all_path, db_path, verbose=True):
     position = 0
 
     # Open the FITs file.
-    with fitsio.FITS(sp_all_path) as hdulist:
+    with fitsio.FITS(catalog_path) as hdulist:
         # This just reads the headers but still takes 15-20 seconds.
         # The equivalent operation with astropy.io.fits takes 15-20 minutes!
 

--- a/bossdata/meta.py
+++ b/bossdata/meta.py
@@ -296,7 +296,8 @@ class Database(object):
             local_path = mirror.local_path(remote_path)
             assert local_path.endswith('.fits'), 'Expected .fits extention for {}.'.format(
                 local_path)
-                db_path = local_path.replace('.fits', '.db')
+            db_path = local_path.replace('.fits', '.db')
+            lite_db_used = False
             # Create the database if necessary.
             if not os.path.isfile(db_path):
                 local_path = mirror.get(remote_path)

--- a/bossdata/meta.py
+++ b/bossdata/meta.py
@@ -277,8 +277,11 @@ class Database(object):
             data. If not specified, the default Manager constructor is used.
         lite(bool): Use the "lite" metadata format, which is considerably faster but only
             provides a subset of the most commonly accessed fields.
+        quasar_catalog(bool): Initialize database using the BOSS quasar catalog instead of spAll.
+        quasar_catalog_name(str): The name of the BOSS quasar catalog or None to use the default
+            defined in :mod:`bossdata.path.Finder`.
     """
-    def __init__(self, finder=None, mirror=None, lite=True, quasar_catalog=False):
+    def __init__(self, finder=None, mirror=None, lite=True, quasar_catalog=False, quasar_catalog_name=None):
 
         if finder is None:
             finder = bossdata.path.Finder()
@@ -289,8 +292,7 @@ class Database(object):
         # database name.
         if quasar_catalog:
             assert not lite, 'No lite format available of BOSS quasar catalog.'
-            remote_path = finder.get_quasar_catalog_path()
-
+            remote_path = finder.get_quasar_catalog_path(quasar_catalog_name)
             local_path = mirror.local_path(remote_path)
             assert local_path.endswith('.fits'), 'Expected .fits extention for {}.'.format(
                 local_path)
@@ -299,7 +301,6 @@ class Database(object):
             if not os.path.isfile(db_path):
                 local_path = mirror.get(remote_path)
                 create_meta_full(local_path, db_path)
-
         else:
             # Pre-build all our paths, test for (and store) the existence of the DB files
             remote_paths = [finder.get_sp_all_path(lite=True), finder.get_sp_all_path(lite=False)]

--- a/bossdata/path.py
+++ b/bossdata/path.py
@@ -52,6 +52,7 @@ class Finder(object):
         if redux_version is None:
             raise ValueError('No redux version specifed: try setting $BOSS_REDUX_VERSION.')
 
+        self.sas_root = sas_root
         self.redux_version = redux_version
         self.redux_base = os.path.join(sas_root, 'spectro', 'redux', redux_version)
 
@@ -122,6 +123,22 @@ class Finder(object):
         else:
             name = 'spAll-{}.fits'.format(self.redux_version)
         return os.path.join(self.redux_base, name)
+
+    def get_quasar_catalog_path(self):
+        """Get the location of the quasar catalog file.
+
+        The data model of the quasar catalog is at
+        http://data.sdss3.org/datamodel/files/BOSS_QSO/DR12Q/DR12Q.html
+        As of DR12, the file size is about 513Mb.
+
+        Additional information is available at
+        http://www.sdss.org/dr12/algorithms/boss-dr12-quasar-catalog/
+        """
+        # How do we want to specify this? 
+        #    function arg, env var, guess from sas_path?
+        catalog_name = 'DR12Q'
+        filename = '{}.fits'.format(catalog_name)
+        return os.path.join(self.sas_root, 'qso', catalog_name, filename)
 
     def get_spec_path(self, plate, mjd, fiber, lite=True):
         """Get the location of the spectrum file for the specified observation.

--- a/bossdata/path.py
+++ b/bossdata/path.py
@@ -124,14 +124,12 @@ class Finder(object):
             name = 'spAll-{}.fits'.format(self.redux_version)
         return os.path.join(self.redux_base, name)
 
-    @staticmethod
-    def get_default_quasar_catalog_name():
-        """Get the default quasar catalog name.
+    default_quasar_catalog_name = 'DR12Q'
+    """Default quasar catalog name.
 
-        For more info about the BOSS quasar catalog, see
-        http://www.sdss.org/dr12/algorithms/boss-dr12-quasar-catalog/
-        """
-        return 'DR12Q'
+    For more info about the BOSS quasar catalog, see
+    http://www.sdss.org/dr12/algorithms/boss-dr12-quasar-catalog/
+    """
 
     def get_quasar_catalog_path(self, catalog_name=None):
         """Get the location of the quasar catalog file.
@@ -148,7 +146,7 @@ class Finder(object):
                 :meth:`get_default_quasar_catalog_name` method if this is not set.
         """
         if catalog_name is None:
-            catalog_name = self.get_default_quasar_catalog_name()
+            catalog_name = self.default_quasar_catalog_name
         filename = '{}.fits'.format(catalog_name)
         return os.path.join(self.sas_root, 'qso', catalog_name, filename)
 

--- a/bossdata/path.py
+++ b/bossdata/path.py
@@ -142,7 +142,7 @@ class Finder(object):
         http://www.sdss.org/dr12/algorithms/boss-dr12-quasar-catalog/
 
         Args:
-            catalog_name(str): BOSS quasar catalog name. Will use the 
+            catalog_name(str): BOSS quasar catalog name. Will use the
                 :meth:`get_default_quasar_catalog_name` method if this is not set.
         """
         if catalog_name is None:

--- a/bossdata/path.py
+++ b/bossdata/path.py
@@ -124,7 +124,16 @@ class Finder(object):
             name = 'spAll-{}.fits'.format(self.redux_version)
         return os.path.join(self.redux_base, name)
 
-    def get_quasar_catalog_path(self):
+    @staticmethod
+    def get_default_quasar_catalog_name():
+        """Get the default quasar catalog name.
+
+        For more info about the BOSS quasar catalog, see
+        http://www.sdss.org/dr12/algorithms/boss-dr12-quasar-catalog/
+        """
+        return 'DR12Q'
+
+    def get_quasar_catalog_path(self, catalog_name=None):
         """Get the location of the quasar catalog file.
 
         The data model of the quasar catalog is at
@@ -133,10 +142,13 @@ class Finder(object):
 
         Additional information is available at
         http://www.sdss.org/dr12/algorithms/boss-dr12-quasar-catalog/
+
+        Args:
+            catalog_name(str): BOSS quasar catalog name. Will use the 
+                :meth:`get_default_quasar_catalog_name` method if this is not set.
         """
-        # How do we want to specify this? 
-        #    function arg, env var, guess from sas_path?
-        catalog_name = 'DR12Q'
+        if catalog_name is None:
+            catalog_name = self.get_default_quasar_catalog_name()
         filename = '{}.fits'.format(catalog_name)
         return os.path.join(self.sas_root, 'qso', catalog_name, filename)
 

--- a/bossdata/plate.py
+++ b/bossdata/plate.py
@@ -224,6 +224,7 @@ class TraceSet(object):
             y[i] = numpy.polynomial.legendre.legval(xvec, self.coefs[i])
         return y
 
+
 class FrameFile(object):
     """A BOSS frame file containing a single exposure of one spectrograph (500 fibers).
 

--- a/bossdata/remote.py
+++ b/bossdata/remote.py
@@ -119,7 +119,7 @@ class Manager(object):
                 raise RuntimeError('HTTP request returned error code {} for {}.'.format(
                     request.status_code, url))
         except requests.exceptions.RequestException as e:
-            raise RuntimeError('HTTP request failed for {}: {}.'.format(url,str(e)))
+            raise RuntimeError('HTTP request failed for {}: {}.'.format(url, str(e)))
 
         # Check that there is enough free space, if possible.
         progress_bar = None
@@ -197,13 +197,8 @@ class Manager(object):
                     mirror = bossdata.remote.Manager()
                     remote_paths = [the_preferred_path, a_backup_path]
                     local_path = mirror.get(remote_paths)
-                    
-                    ...
-                    
-                    relative_local_path = local_path.replace(mirror.local_root, '', 1)
-                    if relative_local_path != remote_paths[0]:
-                        print("A substitution was made:\\n\\t{}\\nwas substituted for\\n\\t{}.".format(
-                            relative_local_path, remote_paths[0]))
+                    if local_path != remote_paths[0]:
+                        print('substituted {} for {}.'.format(local_path, remote_paths[0]))
 
             progress_min_size(int): Display a text progress bar for any downloads whose size
                 in Mb exceeds this value. No progress bar will ever be shown if this


### PR DESCRIPTION
This is about the minimum amount of work I could possibly have done to perform queries on the DR12Q catalog via `boss query` (see #11 ).

A user can perform queries on the quasar catalog using the `--quasar-catalog` option. Note that `--full` also needs to specified because there is no (documented) lite version of the quasar catalog. For example:

```
$ bossquery --verbose --print --full --quasar-catalog --what PLATE,MJD,FIBER,RA,DEC,Z_VI,Z_PIPE --where "" --print --max-rows 10
Database contains 297301 rows.
Query returned 10 rows.
PLATE  MJD  FIBER        RA             DEC            Z_VI         Z_PIPE   
----- ----- ----- ---------------- -------------- ------------- -------------
 6173 56238   528 0.00189828518376  17.7737391299 2.30909729004 2.30909729004
 6177 56268   595 0.00275643009297  14.9746754937 2.49794077873 2.49794077873
 4415 55831   464 0.00405238853989  4.82978057467 1.61884605885 1.61884605885
 4354 55810   678 0.00531697386447 -2.03327328857 1.36035752296 1.36035752296
 4354 55810   646 0.00574621499496 -1.32500879187         2.328 2.33265471458
 6110 56279    86 0.00591211508117  20.0122584631          3.09 3.08883881569
 6498 56565   177  0.0068187989383  30.5193561212         2.377 2.37329888344
 7147 56574   158 0.00735938662115 -7.48592663047         2.538 2.54230260849
 6177 56268   608  0.0075785472626  14.1973854462 3.71199345589 3.71199345589
 4216 55477   312 0.00806669135031 -0.24097078526         2.163 2.16455936432
```
