### PR TITLE
Axis range play

### DIFF
--- a/bin/bossplot
+++ b/bin/bossplot
@@ -9,7 +9,6 @@ from __future__ import division,print_function
 
 from astropy.utils.compat import argparse
 
-import sys
 import os.path
 
 import numpy as np
@@ -39,8 +38,7 @@ def auto_range(range_str, default_limits, data_lo=None, data_hi=None):
             else:
                 return float(limit)
         except ValueError:
-            print('WARNING: invalid limit specified ({})'.format(limit))
-            sys.exit(2)
+            raise ValueError('Invalid limit specified ({})'.format(limit))
 
     if isinstance(default_limits, basestring): #Then parse; no blanks, is default!
         def_lo, def_hi = default_limits.split(':')
@@ -54,8 +52,7 @@ def auto_range(range_str, default_limits, data_lo=None, data_hi=None):
     new_lo = _limit_parser(lo, default_lo, data_lo)
     new_hi = _limit_parser(hi, default_hi, data_hi)
     if abs(new_hi-new_lo) < 0.1 or not abs(new_hi-new_lo) < float('inf'):
-        print('WARNING: limits resulted in invalid range {:.4}:{:.4}'.format(new_lo, new_hi))
-        sys.exit(2)
+        raise ValueError('Limits resulted in invalid range {:.4}:{:.4}'.format(new_lo, new_hi))
     if new_hi < new_lo:
         new_lo, new_hi = new_hi, new_lo
     return new_lo, new_hi
@@ -305,21 +302,35 @@ def main():
     plt.xlim(wlen_min, wlen_max)
     # Adjust wlen axis range, if requested
     if args.wlen_range:
-        wlen_min, wlen_max = auto_range(args.wlen_range, left_axis.get_xlim())
-        left_axis.set_xlim(wlen_min, wlen_max)
+        try:
+            wlen_min, wlen_max = auto_range(args.wlen_range, left_axis.get_xlim())
+            left_axis.set_xlim(wlen_min, wlen_max)
+        except ValueError as e:
+            print(e)
+            return -2
 
     # Adjust flux axis range, if requested
     if args.flux_range:
-        valid = ~flux_lo.mask & ~flux_hi.mask & (wlen_data > wlen_min) & (wlen_data < wlen_max)
-        flux_min, flux_max = auto_range(args.flux_range, "0.5%:99.5%",
-            data_lo=flux_lo[valid], data_hi=flux_hi[valid])
-        left_axis.set_ylim(flux_min, flux_max)
+        try:
+            valid = (~flux_lo.mask & ~flux_hi.mask & (wlen_data > wlen_min) &
+                (wlen_data < wlen_max))
+            flux_min, flux_max = auto_range(args.flux_range, "0.5%:99.5%",
+                data_lo=flux_lo[valid], data_hi=flux_hi[valid])
+            left_axis.set_ylim(flux_min, flux_max)
+        except ValueError as e:
+            print(e)
+            return -2
 
     # Adjust dispersion axis range, if requested
     if args.show_dispersion and args.wdisp_range is not None:
-        valid = ~wdisp_data.mask & (wlen_data > wlen_min) & (wlen_data < wlen_max)
-        wdisp_min, wdisp_max = auto_range(args.wdisp_range, right_axis.get_ylim(), wdisp_data[valid])
-        right_axis.set_ylim(wdisp_min, wdisp_max)
+        try:
+            valid = ~wdisp_data.mask & (wlen_data > wlen_min) & (wlen_data < wlen_max)
+            wdisp_min, wdisp_max = auto_range(args.wdisp_range, right_axis.get_ylim(),
+                                              wdisp_data[valid])
+            right_axis.set_ylim(wdisp_min, wdisp_max)
+        except ValueError as e:
+            print(e)
+            return -2
 
     # Set masking to be dispersion range hieght
     if args.show_mask and len(x_mask)>0:

--- a/bin/bossplot
+++ b/bin/bossplot
@@ -22,6 +22,41 @@ import bossdata.spec
 import bossdata.bits
 import bossdata.plate
 
+def set_yaxis_limits(axis, limits, data_lo=None, data_hi=None):
+    if data_hi is None:
+        data_hi = data_lo
+    old_lo, old_hi = axis.get_ylim()
+    arg_lo, arg_hi = limits.split(':')
+    def _limit_parser(limit, old_limit, data):
+        if limit.endswith('%'):
+            assert data is not None, 'must specify data array when using quantile limit'
+            limit_frac = float(limit.rstrip('%'))
+            return np.percentile(data, limit_frac)
+        else:
+            try:
+                return float(limit)
+            except ValueError:
+                return old_limit
+    new_lo = _limit_parser(arg_lo, old_lo, data_lo)
+    new_hi = _limit_parser(arg_hi, old_hi, data_hi)
+    axis.set_ylim(new_lo, new_hi)
+
+def set_xaxis_limits(axis, limits):
+    old_lo, old_hi = axis.get_xlim()
+    arg_lo, arg_hi = limits.split(':')
+    def _limit_parser(limit, old_limit):
+        if limit.endswith('%'):
+            limit_frac = float(limit.rstrip('%'))
+            return old_lo + (old_hi - old_lo)*limit_frac/100.0
+        else:
+            try:
+                return float(limit)
+            except ValueError:
+                return old_limit
+    new_lo = _limit_parser(arg_lo, old_lo)
+    new_hi = _limit_parser(arg_hi, old_hi)
+    axis.set_xlim(new_lo, new_hi)
+
 def print_mask_summary(label, mask_values):
     if np.any(mask_values):
         print('{0} pixel mask summary:'.format(label))

--- a/bin/bossplot
+++ b/bin/bossplot
@@ -10,6 +10,7 @@ from __future__ import division,print_function
 from astropy.utils.compat import argparse
 
 import os.path
+import math
 import re
 
 import numpy as np
@@ -31,13 +32,16 @@ def auto_range(range_str, default_limits, data_lo=None, data_hi=None):
             if limit.endswith('%'):
                 limit_frac = float(limit.rstrip('%'))
                 if data is not None:
-                    return np.percentile(data, limit_frac)
+                    value = np.percentile(data, limit_frac)
                 else:
-                    return default_lo + (default_hi - default_lo)*limit_frac/100.0
+                    value = default_lo + (default_hi - default_lo)*limit_frac/100.0
             elif limit == '':
-                return default_limit
+                value = default_limit
             else:
-                return float(limit)
+                value = float(limit)
+            if math.isinf(value) or math.isnan(value):
+                raise ValueError()
+            return value
         except ValueError:
             raise ValueError('Invalid limit specified ({})'.format(limit))
 
@@ -55,11 +59,8 @@ def auto_range(range_str, default_limits, data_lo=None, data_hi=None):
     lo, hi = parsed.groups()
     new_lo = _limit_parser(lo, default_lo, data_lo)
     new_hi = _limit_parser(hi, default_hi, data_hi)
-    if abs(new_hi-new_lo) < 0.1 or not abs(new_hi-new_lo) < float('inf'):
-        raise ValueError('Limits resulted in invalid range [{:.4}:{:.4}]'.format(
-            new_lo, new_hi))
-    if new_hi < new_lo:
-        new_lo, new_hi = new_hi, new_lo
+    if new_hi <= new_lo:
+        raise ValueError('Must have min < max in range {}.'.format(range_str))
     return new_lo, new_hi
 
 def print_mask_summary(label, mask_values):

--- a/bin/bossplot
+++ b/bin/bossplot
@@ -251,6 +251,7 @@ def main():
     flux_lo, flux_hi = np.array([], dtype=float), np.array([], dtype=float)
     wdisp_data = np.array([], dtype=float)
     wlen_data = np.array([], dtype=float)
+    x_mask = [ ]
     for data,plot_color in zip(spectra,plot_colors):
 
         wlen,dflux = data['wavelength'][:],data['dflux'][:]
@@ -268,14 +269,9 @@ def main():
 
         num_masked = len(data.mask)
         if args.show_mask and num_masked > 0:
-            x_mask = [ ]
-            y_mask = [ ]
-            ymin,ymax = left_axis.get_ylim()
             bad_pixels = np.where(data.mask)
             for x in data.data['wavelength'][bad_pixels]:
                 x_mask.extend([x,x,None])
-                y_mask.extend([ymin,ymax,None])
-            plt.plot(x_mask,y_mask,'-',color=plot_color,alpha=0.2)
 
         if args.show_dispersion:
             right_axis.plot(wlen,data['wdisp'][:],ls='-',color=plot_color)
@@ -311,6 +307,12 @@ def main():
         valid = ~wdisp_data.mask & (wlen_data > wlen_min) & (wlen_data < wlen_max)
         wdisp_min, wdisp_max = auto_range(args.wdisp_range, right_axis.get_ylim(), wdisp_data[valid])
         right_axis.set_ylim(wdisp_min, wdisp_max)
+
+    # Set masking to be dispersion range hieght
+    if args.show_mask and len(x_mask)>0:
+        ymin,ymax = left_axis.get_ylim()
+        y_mask = [ymin,ymax,None]*int(len(x_mask)/3) # /3 since there are 3 elems per x_entry
+        left_axis.plot(x_mask,y_mask,'-',color=plot_color,alpha=0.2)
 
     if args.save_plot is not None:
         save_name = args.save_plot

--- a/bin/bossplot
+++ b/bin/bossplot
@@ -25,34 +25,26 @@ import bossdata.plate
 def auto_range(range_str, default_limits, data_lo=None, data_hi=None):
     if data_hi is None:
         data_hi = data_lo
-
     def _limit_parser(limit, default_limit, data):
-        s_limit, type_flag = limit.strip(), '#'
-        limit_val = default_limit
-        if s_limit.endswith('%'):
-            s_limit, type_flag = limit.rstrip('%'), '%'
-
         try:
-            limit_val = float(s_limit)
-        except ValueError:
-            print("WARNING: {} doesn't appear to be a number or percent. The unmodified value "\
-                    "{} was used instead.".format(limit, default_limit) )
-            return default_limit
-
-        if type_flag == '%':
-            if data is not None:
-                return np.percentile(data, limit_val)
+            if limit.endswith('%'):
+                limit_frac = float(limit.rstrip('%'))
+                if data is not None:
+                    return np.percentile(data, limit_frac)
+                else:
+                    return default_lo + (default_hi - default_lo)*limit_frac/100.0
+            elif limit == '':
+                return default_limit
             else:
-                return default_lo + (default_hi - default_lo)*limit_val/100.0
-        else:
-            return limit_val
+                return float(limit)
+        except ValueError:
+            print('Warning: invalid limit specified ({}) using default.'.format(range_str))
+            return default_limit
 
     lo, hi = range_str.split(':')
     default_lo, default_hi = default_limits
     new_lo = _limit_parser(lo, default_lo, data_lo)
     new_hi = _limit_parser(hi, default_hi, data_hi)
-    if new_hi < new_lo:
-        new_hi, new_lo = new_lo, new_hi
     return new_lo, new_hi
 
 def print_mask_summary(label, mask_values):
@@ -106,12 +98,11 @@ def main():
     parser.add_argument('--add-sky', action = 'store_true',
         help = 'Add the subtracted sky to the object flux (overrides show-sky).')
     parser.add_argument('--flux-range', type=str, default='0.5%:99.5%', metavar="MIN:MAX",
-        help='Limit flux axis range. MIN or MAX may be either a number, percent, or blank, '\
-            'e.g. 10%%:90%%, 5000:95%%, 4750:')
+        help='Limit flux axis range. MIN or MAX may be either a number, percent, or blank.')
     parser.add_argument('--wlen-range', type=str, default=None, metavar="MIN:MAX",
-        help='Limit wavelength axis range. MIN:MAX follows --flux-range format.')
+        help='Limit wavelength axis range. MIN or MAX may be either a number, percent, or blank.')
     parser.add_argument('--wdisp-range', type=str, default=None, metavar="MIN:MAX",
-        help='Limit dispersion axis range. MIN:MAX follows --flux-range format.')
+        help='Limit dispersion axis range. MIN or MAX may be either a number, percent, or blank.')
     parser.add_argument('--figsize', type=str, default='12,8', metavar="WIDTH,HEIGHT",
         help='Figure dimensions in inches.')
     args = parser.parse_args()

--- a/bin/bossplot
+++ b/bin/bossplot
@@ -49,6 +49,7 @@ def auto_range(range_str, default_limits, data_lo=None, data_hi=None):
     else: #Assume e.g. limits from get_xlim
         default_lo, default_hi = default_limits
 
+    range_str = range_str.strip("[] ")
     lo, hi = range_str.split(':')
     new_lo = _limit_parser(lo, default_lo, data_lo)
     new_hi = _limit_parser(hi, default_hi, data_hi)
@@ -108,11 +109,11 @@ def main():
         help = 'Show the subtracted sky flux instead of the object flux.')
     parser.add_argument('--add-sky', action = 'store_true',
         help = 'Add the subtracted sky to the object flux (overrides show-sky).')
-    parser.add_argument('--flux-range', type=str, default='0.5%:99.5%', metavar="MIN:MAX",
+    parser.add_argument('--flux-range', type=str, default='0.5%:99.5%', metavar="[MIN:MAX]",
         help='Limit flux axis range. MIN or MAX may be either a number, percent, or blank.')
-    parser.add_argument('--wlen-range', type=str, default=None, metavar="MIN:MAX",
+    parser.add_argument('--wlen-range', type=str, default=None, metavar="[MIN:MAX]",
         help='Limit wavelength axis range. MIN or MAX may be either a number, percent, or blank.')
-    parser.add_argument('--wdisp-range', type=str, default=None, metavar="MIN:MAX",
+    parser.add_argument('--wdisp-range', type=str, default=None, metavar="[MIN:MAX]",
         help='Limit dispersion axis range. MIN or MAX may be either a number, percent, or blank.')
     parser.add_argument('--figsize', type=str, default='12,8', metavar="WIDTH,HEIGHT",
         help='Figure dimensions in inches.')

--- a/bin/bossplot
+++ b/bin/bossplot
@@ -9,6 +9,7 @@ from __future__ import division,print_function
 
 from astropy.utils.compat import argparse
 
+import sys
 import os.path
 
 import numpy as np
@@ -38,9 +39,8 @@ def auto_range(range_str, default_limits, data_lo=None, data_hi=None):
             else:
                 return float(limit)
         except ValueError:
-            print('WARNING: invalid limit specified ({}) using corresponding default '\
-                '{:.4}.'.format(limit, default_limit))
-            return default_limit
+            print('WARNING: invalid limit specified ({})'.format(limit))
+            sys.exit(2)
 
     if isinstance(default_limits, basestring): #Then parse; no blanks, is default!
         def_lo, def_hi = default_limits.split(':')
@@ -54,9 +54,10 @@ def auto_range(range_str, default_limits, data_lo=None, data_hi=None):
     new_lo = _limit_parser(lo, default_lo, data_lo)
     new_hi = _limit_parser(hi, default_hi, data_hi)
     if abs(new_hi-new_lo) < 0.1 or not abs(new_hi-new_lo) < float('inf'):
-        print('WARNING: limits resulted in invalid range {:.4}:{:.4}, using default range '\
-            '{:.4}:{:.4}.'.format(new_lo, new_hi, default_lo, default_hi))
-        return default_lo, default_hi
+        print('WARNING: limits resulted in invalid range {:.4}:{:.4}'.format(new_lo, new_hi))
+        sys.exit(2)
+    if new_hi < new_lo:
+        new_lo, new_hi = new_hi, new_lo
     return new_lo, new_hi
 
 def print_mask_summary(label, mask_values):

--- a/bin/bossplot
+++ b/bin/bossplot
@@ -10,6 +10,7 @@ from __future__ import division,print_function
 from astropy.utils.compat import argparse
 
 import os.path
+import re
 
 import numpy as np
 import numpy.ma
@@ -47,12 +48,16 @@ def auto_range(range_str, default_limits, data_lo=None, data_hi=None):
     else: #Assume e.g. limits from get_xlim
         default_lo, default_hi = default_limits
 
-    range_str = range_str.strip("[] ")
-    lo, hi = range_str.split(':')
+    # The range must be have the format [ <lo> : <hi> ]
+    parsed = re.match('\s*\[\s*(.*?)\s*:\s*(.*?)\s*\]\s*', range_str)
+    if not parsed:
+        raise ValueError('Range does not have the format [<lo>:<hi>].')
+    lo, hi = parsed.groups()
     new_lo = _limit_parser(lo, default_lo, data_lo)
     new_hi = _limit_parser(hi, default_hi, data_hi)
     if abs(new_hi-new_lo) < 0.1 or not abs(new_hi-new_lo) < float('inf'):
-        raise ValueError('Limits resulted in invalid range {:.4}:{:.4}'.format(new_lo, new_hi))
+        raise ValueError('Limits resulted in invalid range [{:.4}:{:.4}]'.format(
+            new_lo, new_hi))
     if new_hi < new_lo:
         new_lo, new_hi = new_hi, new_lo
     return new_lo, new_hi

--- a/bin/bossplot
+++ b/bin/bossplot
@@ -45,8 +45,14 @@ def auto_range(range_str, default_limits, data_lo=None, data_hi=None):
         except ValueError:
             raise ValueError('Invalid limit specified ({}).'.format(limit))
 
-    if isinstance(default_limits, basestring): #Then parse; no blanks, is default!
-        def_lo, def_hi = default_limits.split(':')
+    range_pattern = re.compile('\s*\[\s*(.*?)\s*:\s*(.*?)\s*\]\s*')
+
+    if isinstance(default_limits, basestring):
+        parsed = re.match(range_pattern, default_limits)
+        if not parsed:
+            raise ValueError('Default range {} does not have the format [<lo>:<hi>].'.format(
+                range_str))
+        def_lo, def_hi = parsed.groups()
         default_lo = _limit_parser(def_lo, 0, data_lo)
         default_hi = _limit_parser(def_hi, 0, data_hi)
     else: #Assume e.g. limits from get_xlim

--- a/bin/bossplot
+++ b/bin/bossplot
@@ -38,13 +38,24 @@ def auto_range(range_str, default_limits, data_lo=None, data_hi=None):
             else:
                 return float(limit)
         except ValueError:
-            print('Warning: invalid limit specified ({}) using default.'.format(range_str))
+            print('WARNING: invalid limit specified ({}) using corresponding default '\
+                '{:.4}.'.format(limit, default_limit))
             return default_limit
 
+    if isinstance(default_limits, basestring): #Then parse; no blanks, is default!
+        def_lo, def_hi = default_limits.split(':')
+        default_lo = _limit_parser(def_lo, 0, data_lo)
+        default_hi = _limit_parser(def_hi, 0, data_hi)
+    else: #Assume e.g. limits from get_xlim
+        default_lo, default_hi = default_limits
+
     lo, hi = range_str.split(':')
-    default_lo, default_hi = default_limits
     new_lo = _limit_parser(lo, default_lo, data_lo)
     new_hi = _limit_parser(hi, default_hi, data_hi)
+    if abs(new_hi-new_lo) < 0.1 or not abs(new_hi-new_lo) < float('inf'):
+        print('WARNING: limits resulted in invalid range {:.4}:{:.4}, using default range '\
+            '{:.4}:{:.4}.'.format(new_lo, new_hi, default_lo, default_hi))
+        return default_lo, default_hi
     return new_lo, new_hi
 
 def print_mask_summary(label, mask_values):
@@ -298,7 +309,7 @@ def main():
     # Adjust flux axis range, if requested
     if args.flux_range:
         valid = ~flux_lo.mask & ~flux_hi.mask & (wlen_data > wlen_min) & (wlen_data < wlen_max)
-        flux_min, flux_max = auto_range(args.flux_range, left_axis.get_ylim(),
+        flux_min, flux_max = auto_range(args.flux_range, "0.5%:99.5%",
             data_lo=flux_lo[valid], data_hi=flux_hi[valid])
         left_axis.set_ylim(flux_min, flux_max)
 

--- a/bin/bossplot
+++ b/bin/bossplot
@@ -260,6 +260,7 @@ def main():
     wlen_min,wlen_max = +1e6,-1e6
     flux_lo, flux_hi = np.array([], dtype=float), np.array([], dtype=float)
     wdisp_data = np.array([], dtype=float)
+    wlen_data = np.array([], dtype=float)
     for data,plot_color in zip(spectra,plot_colors):
 
         wlen,dflux = data['wavelength'][:],data['dflux'][:]
@@ -298,15 +299,19 @@ def main():
         flux_lo = numpy.ma.append(flux_lo, flux - dflux)
         flux_hi = numpy.ma.append(flux_hi, flux + dflux)
 
+        # Update the list of wavelengths that we will use to auto-range the vertical scale.
+        wlen_data = numpy.ma.append(wlen_data, wlen)
+
     # The x-axis limits are reset by the twinx() function so we set them here.
     plt.xlim(wlen_min, wlen_max)
     # Adjust wlen axis range, if requested
     if args.wlen_range:
         set_xaxis_limits(left_axis, args.wlen_range)
+        wlen_min, wlen_max = left_axis.get_xlim()
 
     # Adjust flux axis range, if requested
     if args.flux_range:
-        valid = ~flux_lo.mask & ~flux_hi.mask
+        valid = ~flux_lo.mask & ~flux_hi.mask & (wlen_data > wlen_min) & (wlen_data < wlen_max)
         set_yaxis_limits(left_axis, args.flux_range, data_lo=flux_lo[valid], data_hi=flux_hi[valid])
 
     # Adjust dispersion axis range, if requested

--- a/bin/bossplot
+++ b/bin/bossplot
@@ -185,7 +185,8 @@ def main():
         return -1
 
     # Initialize the plot.
-    figure = plt.figure(figsize=(12,8))
+    figsize = [float(value) for value in args.figsize.split(',')]
+    figure = plt.figure(figsize=figsize, tight_layout=True)
     left_axis = plt.gca()
     figure.set_facecolor('white')
     plt.xlabel('Wavelength ($\AA$)')

--- a/bin/bossplot
+++ b/bin/bossplot
@@ -43,7 +43,7 @@ def auto_range(range_str, default_limits, data_lo=None, data_hi=None):
                 raise ValueError()
             return value
         except ValueError:
-            raise ValueError('Invalid limit specified ({})'.format(limit))
+            raise ValueError('Invalid limit specified ({}).'.format(limit))
 
     if isinstance(default_limits, basestring): #Then parse; no blanks, is default!
         def_lo, def_hi = default_limits.split(':')
@@ -113,13 +113,13 @@ def main():
         help = 'Show the subtracted sky flux instead of the object flux.')
     parser.add_argument('--add-sky', action = 'store_true',
         help = 'Add the subtracted sky to the object flux (overrides show-sky).')
-    parser.add_argument('--flux-range', type=str, default='0.5%:99.5%', metavar="[MIN:MAX]",
+    parser.add_argument('--flux-range', type=str, default='[0.5%:99.5%]', metavar='[MIN:MAX]',
         help='Limit flux axis range. MIN or MAX may be either a number, percent, or blank.')
-    parser.add_argument('--wlen-range', type=str, default=None, metavar="[MIN:MAX]",
+    parser.add_argument('--wlen-range', type=str, default=None, metavar='[MIN:MAX]',
         help='Limit wavelength axis range. MIN or MAX may be either a number, percent, or blank.')
-    parser.add_argument('--wdisp-range', type=str, default=None, metavar="[MIN:MAX]",
+    parser.add_argument('--wdisp-range', type=str, default=None, metavar='[MIN:MAX]',
         help='Limit dispersion axis range. MIN or MAX may be either a number, percent, or blank.')
-    parser.add_argument('--figsize', type=str, default='12,8', metavar="WIDTH,HEIGHT",
+    parser.add_argument('--figsize', type=str, default='12,8', metavar='WIDTH,HEIGHT',
         help='Figure dimensions in inches.')
     args = parser.parse_args()
 
@@ -184,7 +184,7 @@ def main():
                 print(specfile.exposure_table)
                 relative_local_path = local_path.replace(mirror.local_root, '', 1)
                 if relative_local_path != remote_paths[0]:
-                    print("A substitution was made:\n\t{}\nwas substituted for\n\t{}.".format(
+                    print('A substitution was made:\n\t{}\nwas substituted for\n\t{}.'.format(
                         relative_local_path, remote_paths[0]))
     except RuntimeError as e:
         print(str(e))
@@ -320,7 +320,7 @@ def main():
         try:
             valid = (~flux_lo.mask & ~flux_hi.mask & (wlen_data > wlen_min) &
                 (wlen_data < wlen_max))
-            flux_min, flux_max = auto_range(args.flux_range, "0.5%:99.5%",
+            flux_min, flux_max = auto_range(args.flux_range, '0.5%:99.5%',
                 data_lo=flux_lo[valid], data_hi=flux_hi[valid])
             left_axis.set_ylim(flux_min, flux_max)
         except ValueError as e:

--- a/bin/bossplot
+++ b/bin/bossplot
@@ -24,17 +24,36 @@ import bossdata.spec
 import bossdata.bits
 import bossdata.plate
 
-def auto_range(range_str, default_limits, data_lo=None, data_hi=None):
+def auto_range(range_str, abs_lo, abs_hi, default_limits, data_lo=None, data_hi=None):
+    """
+    Interpret an axis range specification.
+
+    Percentage lo/hi limits are interpreted as percentiles when data_lo/data_hi is
+    provided and the limit value is 0-100%.  Otheriwse, the limit value is calculated
+    as::
+
+        abs_lo + (abs_hi - abs_lo) * limit/100
+
+    Args:
+        range_str(str): A range specification of the form [ <lo> : <hi> ].
+        abs_lo(float): The absolute lower bound for data on this axis.
+        abs_hi(float): The absolute upper bound for data on this axis.
+        default_limits(str): A default range specification of the form [ <lo> : <hi> ].
+        data_lo(numpy.ndarray): An array of values whose percentile is used to
+            calculate lo limits when the limit value is 0-100%.
+        data_hi(numpy.ndarray): An array of values whose percentile is used to
+            calculate hi limits when the limit value is 0-100%.
+    """
     if data_hi is None:
         data_hi = data_lo
     def _limit_parser(limit, default_limit, data):
         try:
             if limit.endswith('%'):
-                limit_frac = float(limit.rstrip('%'))
-                if data is not None:
-                    value = np.percentile(data, limit_frac)
+                limit_percent = float(limit.rstrip('%'))
+                if data is not None and limit_percent > 0 and limit_percent < 100:
+                    value = np.percentile(data, limit_percent)
                 else:
-                    value = default_lo + (default_hi - default_lo)*limit_frac/100.0
+                    value = abs_lo + (abs_hi - abs_lo) * limit_percent / 100.0
             elif limit == '':
                 value = default_limit
             else:
@@ -312,33 +331,36 @@ def main():
 
     # The x-axis limits are reset by the twinx() function so we set them here.
     plt.xlim(wlen_min, wlen_max)
-    # Adjust wlen axis range, if requested
+    # Set the wavelength axis range.
     if args.wlen_range:
         try:
             left_axis.set_xlim(*auto_range(args.wlen_range,
+                wlen_min, wlen_max,
                 parser.get_default('wlen_range') or left_axis.get_xlim()))
         except ValueError as e:
             print(e)
             return -2
 
-    # Adjust flux axis range, if requested
+    # Set the flux axis range.
     if args.flux_range:
         try:
             valid = (~flux_lo.mask & ~flux_hi.mask & (wlen_data > wlen_min) &
                 (wlen_data < wlen_max))
             left_axis.set_ylim(*auto_range(args.flux_range,
+                np.min(flux_lo[valid]), np.max(flux_hi[valid]),
                 parser.get_default('flux_range') or left_axis.get_ylim(),
                 data_lo=flux_lo[valid], data_hi=flux_hi[valid]))
         except ValueError as e:
             print(e)
             return -2
 
-    # Adjust dispersion axis range, if requested
-    if args.show_dispersion and args.wdisp_range is not None:
+    # Set the wavelength dispersion axis range.
+    if args.show_dispersion and args.wdisp_range:
         try:
             valid = ~wdisp_data.mask & (wlen_data > wlen_min) & (wlen_data < wlen_max)
             right_axis.set_ylim(*auto_range(args.wdisp_range,
-                parser.get_default('wlen_range') or right_axis.get_ylim(),
+                np.min(wdisp_data[valid]), np.max(wdisp_data[valid]),
+                parser.get_default('wdisp_range') or right_axis.get_ylim(),
                 wdisp_data[valid]))
         except ValueError as e:
             print(e)

--- a/bin/bossplot
+++ b/bin/bossplot
@@ -22,40 +22,26 @@ import bossdata.spec
 import bossdata.bits
 import bossdata.plate
 
-def set_yaxis_limits(axis, limits, data_lo=None, data_hi=None):
+def auto_range(range_str, default_limits, data_lo=None, data_hi=None):
     if data_hi is None:
         data_hi = data_lo
-    old_lo, old_hi = axis.get_ylim()
-    arg_lo, arg_hi = limits.split(':')
-    def _limit_parser(limit, old_limit, data):
+    def _limit_parser(limit, default_limit, data):
         if limit.endswith('%'):
-            assert data is not None, 'must specify data array when using quantile limit'
             limit_frac = float(limit.rstrip('%'))
-            return np.percentile(data, limit_frac)
+            if data is not None:
+                return np.percentile(data, limit_frac)
+            else:
+                return default_lo + (default_hi - default_lo)*limit_frac/100.0
         else:
             try:
                 return float(limit)
             except ValueError:
-                return old_limit
-    new_lo = _limit_parser(arg_lo, old_lo, data_lo)
-    new_hi = _limit_parser(arg_hi, old_hi, data_hi)
-    axis.set_ylim(new_lo, new_hi)
-
-def set_xaxis_limits(axis, limits):
-    old_lo, old_hi = axis.get_xlim()
-    arg_lo, arg_hi = limits.split(':')
-    def _limit_parser(limit, old_limit):
-        if limit.endswith('%'):
-            limit_frac = float(limit.rstrip('%'))
-            return old_lo + (old_hi - old_lo)*limit_frac/100.0
-        else:
-            try:
-                return float(limit)
-            except ValueError:
-                return old_limit
-    new_lo = _limit_parser(arg_lo, old_lo)
-    new_hi = _limit_parser(arg_hi, old_hi)
-    axis.set_xlim(new_lo, new_hi)
+                return default_limit
+    lo, hi = range_str.split(':')
+    default_lo, default_hi = default_limits
+    new_lo = _limit_parser(lo, default_lo, data_lo)
+    new_hi = _limit_parser(hi, default_hi, data_hi)
+    return new_lo, new_hi
 
 def print_mask_summary(label, mask_values):
     if np.any(mask_values):
@@ -108,13 +94,13 @@ def main():
     parser.add_argument('--add-sky', action = 'store_true',
         help = 'Add the subtracted sky to the object flux (overrides show-sky).')
     parser.add_argument('--flux-range', type=str, default='0.5%:99.5%',
-        help='Force y axis limits.')
+        help='Limit flux axis range.')
     parser.add_argument('--wlen-range', type=str, default=None,
-            help='Force y axis limits.')
+        help='Limit wavelength axis range.')
     parser.add_argument('--wdisp-range', type=str, default=None,
-            help='Force y axis limits.')
+        help='Limit dispersion axis range.')
     parser.add_argument('--figsize', type=str, default='12,8',
-        help='Figure dimension in inches.')
+        help='Figure dimensions in inches.')
     args = parser.parse_args()
 
     if args.exposure is None:
@@ -299,25 +285,28 @@ def main():
         flux_lo = numpy.ma.append(flux_lo, flux - dflux)
         flux_hi = numpy.ma.append(flux_hi, flux + dflux)
 
-        # Update the list of wavelengths that we will use to auto-range the vertical scale.
+        # Update the list of wavelengths that we will use to auto-range the horizontal scale.
         wlen_data = numpy.ma.append(wlen_data, wlen)
 
     # The x-axis limits are reset by the twinx() function so we set them here.
     plt.xlim(wlen_min, wlen_max)
     # Adjust wlen axis range, if requested
     if args.wlen_range:
-        set_xaxis_limits(left_axis, args.wlen_range)
-        wlen_min, wlen_max = left_axis.get_xlim()
+        wlen_min, wlen_max = auto_range(args.wlen_range, left_axis.get_xlim())
+        left_axis.set_xlim(wlen_min, wlen_max)
 
     # Adjust flux axis range, if requested
     if args.flux_range:
         valid = ~flux_lo.mask & ~flux_hi.mask & (wlen_data > wlen_min) & (wlen_data < wlen_max)
-        set_yaxis_limits(left_axis, args.flux_range, data_lo=flux_lo[valid], data_hi=flux_hi[valid])
+        flux_min, flux_max = auto_range(args.flux_range, left_axis.get_ylim(),
+            data_lo=flux_lo[valid], data_hi=flux_hi[valid])
+        left_axis.set_ylim(flux_min, flux_max)
 
     # Adjust dispersion axis range, if requested
     if args.show_dispersion and args.wdisp_range is not None:
-        valid = ~wdisp_data.mask
-        set_yaxis_limits(right_axis, args.wdisp_range, wdisp_data[valid])
+        valid = ~wdisp_data.mask & (wlen_data > wlen_min) & (wlen_data < wlen_max)
+        wdisp_min, wdisp_max = auto_range(args.wdisp_range, right_axis.get_ylim(), wdisp_data[valid])
+        right_axis.set_ylim(wdisp_min, wdisp_max)
 
     if args.save_plot is not None:
         save_name = args.save_plot

--- a/bin/bossplot
+++ b/bin/bossplot
@@ -25,22 +25,34 @@ import bossdata.plate
 def auto_range(range_str, default_limits, data_lo=None, data_hi=None):
     if data_hi is None:
         data_hi = data_lo
+
     def _limit_parser(limit, default_limit, data):
-        if limit.endswith('%'):
-            limit_frac = float(limit.rstrip('%'))
+        s_limit, type_flag = limit.strip(), '#'
+        limit_val = default_limit
+        if s_limit.endswith('%'):
+            s_limit, type_flag = limit.rstrip('%'), '%'
+
+        try:
+            limit_val = float(s_limit)
+        except ValueError:
+            print("WARNING: {} doesn't appear to be a number or percent. The unmodified value "\
+                    "{} was used instead.".format(limit, default_limit) )
+            return default_limit
+
+        if type_flag == '%':
             if data is not None:
-                return np.percentile(data, limit_frac)
+                return np.percentile(data, limit_val)
             else:
-                return default_lo + (default_hi - default_lo)*limit_frac/100.0
+                return default_lo + (default_hi - default_lo)*limit_val/100.0
         else:
-            try:
-                return float(limit)
-            except ValueError:
-                return default_limit
+            return limit_val
+
     lo, hi = range_str.split(':')
     default_lo, default_hi = default_limits
     new_lo = _limit_parser(lo, default_lo, data_lo)
     new_hi = _limit_parser(hi, default_hi, data_hi)
+    if new_hi < new_lo:
+        new_hi, new_lo = new_lo, new_hi
     return new_lo, new_hi
 
 def print_mask_summary(label, mask_values):
@@ -93,13 +105,14 @@ def main():
         help = 'Show the subtracted sky flux instead of the object flux.')
     parser.add_argument('--add-sky', action = 'store_true',
         help = 'Add the subtracted sky to the object flux (overrides show-sky).')
-    parser.add_argument('--flux-range', type=str, default='0.5%:99.5%',
-        help='Limit flux axis range.')
-    parser.add_argument('--wlen-range', type=str, default=None,
-        help='Limit wavelength axis range.')
-    parser.add_argument('--wdisp-range', type=str, default=None,
-        help='Limit dispersion axis range.')
-    parser.add_argument('--figsize', type=str, default='12,8',
+    parser.add_argument('--flux-range', type=str, default='0.5%:99.5%', metavar="MIN:MAX",
+        help='Limit flux axis range. MIN or MAX may be either a number, percent, or blank, '\
+            'e.g. 10%%:90%%, 5000:95%%, 4750:')
+    parser.add_argument('--wlen-range', type=str, default=None, metavar="MIN:MAX",
+        help='Limit wavelength axis range. MIN:MAX follows --flux-range format.')
+    parser.add_argument('--wdisp-range', type=str, default=None, metavar="MIN:MAX",
+        help='Limit dispersion axis range. MIN:MAX follows --flux-range format.')
+    parser.add_argument('--figsize', type=str, default='12,8', metavar="WIDTH,HEIGHT",
         help='Figure dimensions in inches.')
     args = parser.parse_args()
 

--- a/bin/bossplot
+++ b/bin/bossplot
@@ -107,6 +107,14 @@ def main():
         help = 'Show the subtracted sky flux instead of the object flux.')
     parser.add_argument('--add-sky', action = 'store_true',
         help = 'Add the subtracted sky to the object flux (overrides show-sky).')
+    parser.add_argument('--flux-range', type=str, default='0.5%:99.5%',
+        help='Force y axis limits.')
+    parser.add_argument('--wlen-range', type=str, default=None,
+            help='Force y axis limits.')
+    parser.add_argument('--wdisp-range', type=str, default=None,
+            help='Force y axis limits.')
+    parser.add_argument('--figsize', type=str, default='12,8',
+        help='Figure dimension in inches.')
     args = parser.parse_args()
 
     if args.exposure is None:
@@ -250,6 +258,7 @@ def main():
 
     wlen_min,wlen_max = +1e6,-1e6
     flux_lo, flux_hi = np.array([], dtype=float), np.array([], dtype=float)
+    wdisp_data = np.array([], dtype=float)
     for data,plot_color in zip(spectra,plot_colors):
 
         wlen,dflux = data['wavelength'][:],data['dflux'][:]
@@ -278,6 +287,7 @@ def main():
 
         if args.show_dispersion:
             right_axis.plot(wlen,data['wdisp'][:],ls='-',color=plot_color)
+            wdisp_data = numpy.ma.append(wdisp_data, data['wdisp'][:])
 
         # Update the plot wavelength limits to include this data.
         wlen_min = min(wlen_min,np.ma.min(wlen))
@@ -288,11 +298,20 @@ def main():
         flux_hi = numpy.ma.append(flux_hi, flux + dflux)
 
     # The x-axis limits are reset by the twinx() function so we set them here.
-    plt.xlim(wlen_min,wlen_max)
+    plt.xlim(wlen_min, wlen_max)
+    # Adjust wlen axis range, if requested
+    if args.wlen_range:
+        set_xaxis_limits(left_axis, args.wlen_range)
 
-    # Set the flux scale to show 99% of the valid flux +/- dflux range.
-    valid = ~flux_lo.mask & ~flux_hi.mask
-    left_axis.set_ylim(np.percentile(flux_lo[valid], 0.5), np.percentile(flux_hi[valid], 99.5))
+    # Adjust flux axis range, if requested
+    if args.flux_range:
+        valid = ~flux_lo.mask & ~flux_hi.mask
+        set_yaxis_limits(left_axis, args.flux_range, data_lo=flux_lo[valid], data_hi=flux_hi[valid])
+
+    # Adjust dispersion axis range, if requested
+    if args.show_dispersion and args.wdisp_range is not None:
+        valid = ~wdisp_data.mask
+        set_yaxis_limits(right_axis, args.wdisp_range, wdisp_data[valid])
 
     if args.save_plot is not None:
         save_name = args.save_plot

--- a/bin/bossplot
+++ b/bin/bossplot
@@ -59,9 +59,9 @@ def auto_range(range_str, default_limits, data_lo=None, data_hi=None):
         default_lo, default_hi = default_limits
 
     # The range must be have the format [ <lo> : <hi> ]
-    parsed = re.match('\s*\[\s*(.*?)\s*:\s*(.*?)\s*\]\s*', range_str)
+    parsed = re.match(range_pattern, range_str)
     if not parsed:
-        raise ValueError('Range does not have the format [<lo>:<hi>].')
+        raise ValueError('Range {} does not have the format [<lo>:<hi>].'.format(range_str))
     lo, hi = parsed.groups()
     new_lo = _limit_parser(lo, default_lo, data_lo)
     new_hi = _limit_parser(hi, default_hi, data_hi)
@@ -315,8 +315,8 @@ def main():
     # Adjust wlen axis range, if requested
     if args.wlen_range:
         try:
-            wlen_min, wlen_max = auto_range(args.wlen_range, left_axis.get_xlim())
-            left_axis.set_xlim(wlen_min, wlen_max)
+            left_axis.set_xlim(*auto_range(args.wlen_range,
+                parser.get_default('wlen_range') or left_axis.get_xlim()))
         except ValueError as e:
             print(e)
             return -2
@@ -326,9 +326,9 @@ def main():
         try:
             valid = (~flux_lo.mask & ~flux_hi.mask & (wlen_data > wlen_min) &
                 (wlen_data < wlen_max))
-            flux_min, flux_max = auto_range(args.flux_range, '0.5%:99.5%',
-                data_lo=flux_lo[valid], data_hi=flux_hi[valid])
-            left_axis.set_ylim(flux_min, flux_max)
+            left_axis.set_ylim(*auto_range(args.flux_range,
+                parser.get_default('flux_range') or left_axis.get_ylim(),
+                data_lo=flux_lo[valid], data_hi=flux_hi[valid]))
         except ValueError as e:
             print(e)
             return -2
@@ -337,9 +337,9 @@ def main():
     if args.show_dispersion and args.wdisp_range is not None:
         try:
             valid = ~wdisp_data.mask & (wlen_data > wlen_min) & (wlen_data < wlen_max)
-            wdisp_min, wdisp_max = auto_range(args.wdisp_range, right_axis.get_ylim(),
-                                              wdisp_data[valid])
-            right_axis.set_ylim(wdisp_min, wdisp_max)
+            right_axis.set_ylim(*auto_range(args.wdisp_range,
+                parser.get_default('wlen_range') or right_axis.get_ylim(),
+                wdisp_data[valid]))
         except ValueError as e:
             print(e)
             return -2

--- a/bin/scripts.rst
+++ b/bin/scripts.rst
@@ -96,6 +96,16 @@ This should open a new window containing the plot that you will need to close in
 
 You can also save the data shown in a plot using ``--save-data`` with an optional filename (the default is ``bossplot-{plate}-{mjd}-{fiber}.dat``).  Data is saved using the `ascii.basic <http://docs.astropy.org/en/latest/api/astropy.io.ascii.Basic.html#astropy.io.ascii.Basic>`_ format and only wavelengths with valid data are included in the output.
 
+Use ``--wlen-range MIN:MAX`` to specify a wavelength range over which to plot (x-axis), overriding the default, auto-detected range.  Similarly, ``--flux-range MIN:MAX`` and ``--wdisp-range MIN:MAX`` work for the flux (left y-axis) and dispersion (right y-axis).  MIN and MAX can be either blank (which means use the default value), an absolute value (1000), or a percentage (10%), and percentages and absolute values may be mixed.  Working examples::
+
+    --wlen-range :7500
+    --wlen-range 10%:90%
+    --wlen-range 10%:8000
+
+Another visual option is ``--scatter`` will give a scatter plot of the flux rather than the flux +/- error band.
+
+Several options are available to see data beyond just object flux.  Use ``--show-sky`` to show the subtracted sky (modeled) flux, ``--add-sky`` to show the total of object flux and modeled sky flux, ``--show-mask`` to show grayed regions where data has been masked out because it is deemed invalid, and ``--show-dispersion`` to show wavelength dispersion.
+
 The ``bossplot`` command will automatically download the appropriate data file if necessary.  This is 'conservative':  if an existing local file can be used to satisfy a request, no new files will be downloaded.
 
 Different versions of the spectrum can be plotted. By default the spec-lite data file is used for a coadd or the spec file for an individual exposure.  Use the ``--frame`` or ``--cframe`` to plot the spectrum from a plate ``spFrame`` file or its flux-calibrated equivalent ``spCFrame`` file.

--- a/bin/scripts.rst
+++ b/bin/scripts.rst
@@ -102,7 +102,7 @@ Use ``--wlen-range MIN:MAX`` to specify a wavelength range over which to plot (x
     --wlen-range 10%:90%
     --wlen-range 10%:8000
 
-Another visual option is ``--scatter`` will give a scatter plot of the flux rather than the flux +/- error band.
+Another visual option ``--scatter`` will give a scatter plot of the flux rather than the flux +/- error band.
 
 Several options are available to see data beyond just object flux.  Use ``--show-sky`` to show the subtracted sky (modeled) flux, ``--add-sky`` to show the total of object flux and modeled sky flux, ``--show-mask`` to show grayed regions where data has been masked out because it is deemed invalid, and ``--show-dispersion`` to show wavelength dispersion.
 

--- a/bin/scripts.rst
+++ b/bin/scripts.rst
@@ -96,13 +96,17 @@ This should open a new window containing the plot that you will need to close in
 
 You can also save the data shown in a plot using ``--save-data`` with an optional filename (the default is ``bossplot-{plate}-{mjd}-{fiber}.dat``).  Data is saved using the `ascii.basic <http://docs.astropy.org/en/latest/api/astropy.io.ascii.Basic.html#astropy.io.ascii.Basic>`_ format and only wavelengths with valid data are included in the output.
 
-Use ``--wlen-range MIN:MAX`` to specify a wavelength range over which to plot (x-axis), overriding the default, auto-detected range.  Similarly, ``--flux-range MIN:MAX`` and ``--wdisp-range MIN:MAX`` work for the flux (left y-axis) and dispersion (right y-axis).  MIN and MAX can be either blank (which means use the default value), an absolute value (1000), or a percentage (10%), and percentages and absolute values may be mixed.  Working examples::
+Use ``--wlen-range [MIN:MAX]`` to specify a wavelength range over which to plot (x-axis), overriding the default, auto-detected range.  Similarly, ``--flux-range [MIN:MAX]`` and ``--wdisp-range [MIN:MAX]`` work for the flux (left y-axis) and dispersion (right y-axis).  MIN and MAX can be either blank (which means use the default value), an absolute value (1000), or a percentage (10%), and percentages and absolute values may be mixed.  Working examples::
 
-    --wlen-range :7500
-    --wlen-range 10%:90%
-    --wlen-range 10%:8000
+    --wlen-range [:7500]
+    --wlen-range [10%:90%]
+    --wlen-range [10%:8000]
 
-Another visual option ``--scatter`` will give a scatter plot of the flux rather than the flux +/- error band.
+Note that a percentage value between 0-100% is interpreted as a percentile for vertical (flux, wdisp) axes. In all other cases, percentage values specify a limit value equal to a fraction of the full range ``[lo:hi]``::
+
+    limit = lo + fraction*(hi - lo)
+
+and can be < 0% or >100% to include padding. Another visual option ``--scatter`` will give a scatter plot of the flux rather than the flux +/- error band.
 
 Several options are available to see data beyond just object flux.  Use ``--show-sky`` to show the subtracted sky (modeled) flux, ``--add-sky`` to show the total of object flux and modeled sky flux, ``--show-mask`` to show grayed regions where data has been masked out because it is deemed invalid, and ``--show-dispersion`` to show wavelength dispersion.
 


### PR DESCRIPTION
Here is another implementation of axis limit options for bossplot (see #54 #27).

I added an argument to specify the figure size (and use `tight_layout` by default):

```
$ bossplot --plate 4203 --mjd 55447 --fiber 879 --figsize 12,4 --show-dispersion --exposure 1 --cframe
```

![f1](https://cloud.githubusercontent.com/assets/1648834/8426281/6f000bd0-1ec3-11e5-835d-0e46921f404c.png)

Absolute and quantile limits can be mixed, matched, and partially omitted:

```
$ bossplot --plate 4203 --mjd 55447 --fiber 879 --figsize 12,4 --show-dispersion --exposure 1 --cframe  --flux-range 5:75% --wlen-range " -5%:105%" --wdisp-range 0:
```

![f2](https://cloud.githubusercontent.com/assets/1648834/8426402/57448092-1ec4-11e5-840e-0f50368360a2.png)

Even upside down and backwards:

```
$ bossplot --plate 4203 --mjd 55447 --fiber 879 --figsize 12,4 --show-dispersion --exposure 1 --cframe --flux-range 99%:1% --wlen-range 100%:0%
```

![f3](https://cloud.githubusercontent.com/assets/1648834/8426288/77ab3dc2-1ec3-11e5-91fa-916780001f57.png)

I considered trying to unify the x-axis and y-axis methods but decided that there is a fundamental difference in how quantiles should be interpreted for them.
