### PR TITLE
Rework SpecFile logic for using EXPIDnn header keywords

### DIFF
--- a/DESCRIPTION.rst
+++ b/DESCRIPTION.rst
@@ -5,9 +5,7 @@ A python package for working with `spectroscopic data <http://www.sdss.org/dr12/
 * Releases: https://pypi.python.org/pypi/bossdata
 * Code: https://github.com/dkirkby/bossdata
 
-What's new in version 0.2.5:
+What's new in version 0.2.6dev:
 
-* Adds support for spPlate files and platelist metadata.
-* Adds command-line options to customize bossplot axes, add labels and grids, and display invalid data.
-* General documentation cleanup.
-* Better error handling in bossplot.
+* The ``camera`` arg to ``SpecFile.get_valid_data`` (and related methods) should now be ``b1``, ``b2``, ``r1``, ``r2`` instead of ``blue`` or ``red``.
+* Fixes `github issues <https://github.com/dkirkby/bossdata/issues?q=is%3Aissue+is%3Aclosed>`_ #74.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -63,3 +63,8 @@ History
 * Adds command-line options to customize bossplot axes, add labels and grids, and display invalid data.
 * General documentation cleanup.
 * Better error handling in bossplot.
+
+0.2.6 (???)
+-----------
+
+* Fix issues #74

--- a/bin/bossfetch
+++ b/bin/bossfetch
@@ -187,7 +187,7 @@ def main():
     if args.save:
         with open(args.save, 'w') as f:
             for remote_path in remote_paths:
-                f.write(remote_path+'\n')
+                f.write(remote_path + '\n')
         print('Saved {0} remote file names to {1}.'.format(num_files, args.save))
         return 0
 
@@ -208,7 +208,7 @@ def main():
             num_local, num_files, 100 * num_local / num_files, local_bytes / Mb))
         print('This command would download {} new files.'.format(num_files - num_local))
         if num_local < num_files and num_local > 0:
-            fetch_bytes = (local_bytes/num_local) * (num_files - num_local)
+            fetch_bytes = (local_bytes / num_local) * (num_files - num_local)
             print('Estimated total download size is {:.1f} Mb.'.format(fetch_bytes / Mb))
         return 0
 
@@ -222,12 +222,12 @@ def main():
     # Launch subprocesses to handle subsets of remote paths.
     if num_files < args.nproc:
         args.nproc = num_files
-    chunk_size = (len(remote_paths) + args.nproc - 1)//args.nproc
+    chunk_size = (len(remote_paths) + args.nproc - 1) // args.nproc
     processes = []
     for i in range(args.nproc):
         # The last chunk will be shorter if the number of paths does not evenly divide
         # between the subprocesses.
-        chunk = remote_paths[i*chunk_size:(i+1)*chunk_size]
+        chunk = remote_paths[i * chunk_size:(i + 1) * chunk_size]
         process = multiprocessing.Process(target=fetch, args=(chunk, response_queue))
         processes.append(process)
         process.start()
@@ -263,11 +263,11 @@ def main():
 
     if args.verbose:
         print('Fetched {:.1f} Mb for {:d} files.'.format(
-            num_bytes/float(1 << 20), num_fetched))
+            num_bytes / float(1 << 20), num_fetched))
 
     if num_fetched != num_files:
         print('WARNING: {:d} of {:d} files were not fetched.'.format(
-            num_files-num_fetched, num_files),
+            num_files - num_fetched, num_files),
             'Re-run the command after any problems are fixed.')
 
 if __name__ == '__main__':

--- a/bin/bossplot
+++ b/bin/bossplot
@@ -256,10 +256,10 @@ def main():
             remote_path = finder.get_plate_spec_path(plate=args.plate, mjd=args.mjd)
             local_path = mirror.get(remote_path)
             platefile = bossdata.plate.PlateFile(local_path)
-            num_exposures = len(platefile.exposure_table)
+            num_exposures = platefile.exposures.num_exposures
             if args.verbose:
                 print('Exposure summary:')
-                print(platefile.exposure_table)
+                print(platefile.exposures.table)
         else:
             lite = (args.exposure is None)
             remote_paths = [finder.get_spec_path(plate=args.plate, mjd=args.mjd,
@@ -270,10 +270,10 @@ def main():
             local_paths = []
             local_path = mirror.get(remote_paths, local_paths=local_paths)
             specfile = bossdata.spec.SpecFile(local_path)
-            num_exposures = len(specfile.exposure_table)
+            num_exposures = specfile.exposures.num_exposures
             if args.verbose:
                 print('Exposure summary:')
-                print(specfile.exposure_table)
+                print(specfile.exposures.table)
                 if local_path != local_paths[0]:
                     print('Using local full spec file instead of downloading lite file.')
     except (RuntimeError, ValueError) as e:
@@ -351,21 +351,29 @@ def main():
             if args.verbose:
                 print_mask_summary('Red', frames['red'].get_pixel_masks(fibers)[0])
     else:
-        exposure_id = specfile.exposure_table[args.exposure]['exp']
-        if args.verbose:
-            print('Showing exposure {:08d}.'.format(exposure_id))
+        # Which spectrograph is this fiber on for this plate?
+        num_fibers = bossdata.plate.get_num_fibers(args.plate)
+        spec_index = '1' if args.fiber <= num_fibers // 2 else '2'
         if args.camera in ('blue', 'both'):
+            camera = 'b' + spec_index
+            exposure_id = specfile.exposures.get_info(args.exposure, camera)['science']
+            if args.verbose:
+                print('Showing blue exposure {:08d}.'.format(exposure_id))
             spectra.append(specfile.get_valid_data(
-                args.exposure, 'blue', pixel_quality_mask=pixel_quality_mask, **data_args))
+                args.exposure, camera, pixel_quality_mask=pixel_quality_mask, **data_args))
             plot_colors.append('blue')
             if args.verbose:
-                print_mask_summary('Blue', specfile.get_pixel_mask(args.exposure, 'blue'))
+                print_mask_summary('Blue', specfile.get_pixel_mask(args.exposure, camera))
         if args.camera in ('red', 'both'):
+            camera = 'r' + spec_index
+            exposure_id = specfile.exposures.get_info(args.exposure, camera)['science']
+            if args.verbose:
+                print('Showing red exposure {:08d}.'.format(exposure_id))
             spectra.append(specfile.get_valid_data(
-                args.exposure, 'red', pixel_quality_mask=pixel_quality_mask, **data_args))
+                args.exposure, camera, pixel_quality_mask=pixel_quality_mask, **data_args))
             plot_colors.append('red')
             if args.verbose:
-                print_mask_summary('Red', specfile.get_pixel_mask(args.exposure, 'red'))
+                print_mask_summary('Red', specfile.get_pixel_mask(args.exposure, camera))
 
     # Determine this plot's label and use it for the plot window title.
     plot_label = '{plate}-{mjd}-{fiber}'.format(

--- a/bossdata/meta.py
+++ b/bossdata/meta.py
@@ -196,7 +196,7 @@ def create_meta_full(catalog_path, db_path, verbose=True, primary_key='(PLATE,MJ
         # The equivalent operation with astropy.io.fits takes 15-20 minutes!
 
         # table = hdulist[1].read(rows=[position,position+chunk_size])
-        table = hdulist[1][position:(position+chunk_size)]
+        table = hdulist[1][position:(position + chunk_size)]
 
         # Create a new database file.
         sql, num_cols = sql_create_table(
@@ -232,7 +232,7 @@ def create_meta_full(catalog_path, db_path, verbose=True, primary_key='(PLATE,MJ
                     update_var += 1
 
             position += chunk_size
-            end_position = position+chunk_size
+            end_position = position + chunk_size
             if end_position > maxcount:
                 end_position = maxcount
                 if position > maxcount:

--- a/bossdata/plate.py
+++ b/bossdata/plate.py
@@ -16,7 +16,7 @@ import astropy.table
 
 import fitsio
 
-from bossdata.spec import get_exposure_table
+from bossdata.spec import Exposures
 
 
 def get_num_fibers(plate):
@@ -289,7 +289,7 @@ class PlateFile(object):
         self.num_fibers = self.header['NAXIS2']
         # Look up the number of exposures used for this coadd.
         self.num_exposures = self.header['NEXP']
-        self.exposure_table = get_exposure_table(self.header)
+        self.exposures = Exposures(self.header)
         # Calculate the common wavelength grid from header keywords.
         num_pixels = self.header['NAXIS1']
         loglam_min = self.header['COEFF0']

--- a/bossdata/plate.py
+++ b/bossdata/plate.py
@@ -124,7 +124,7 @@ class Plan(object):
         if fiber < 1 or fiber > self.num_fibers:
             raise ValueError('Invalid fiber {} should be in the range 1-{} for plate {}.'
                              .format(fiber, self.num_fibers, self.plate))
-        return 1 if fiber <= self.num_fibers//2 else 2
+        return 1 if fiber <= self.num_fibers // 2 else 2
 
     def get_exposure_name(self, sequence_number, camera, fiber, calibrated=True):
         """Get the name of a science exposure from this plan.
@@ -260,7 +260,7 @@ class TraceSet(object):
         for i in range(self.ntrace):
             x = np.copy(xpos[i])
             if self.has_jump and not ignore_jump:
-                t = (x - self.xjump_lo)/(self.xjump_hi - self.xjump_lo)
+                t = (x - self.xjump_lo) / (self.xjump_hi - self.xjump_lo)
                 below = x < self.xjump_hi
                 above = x >= self.xjump_lo
                 jump_frac = 1.0 * (~below) + t * (below & above)
@@ -466,7 +466,7 @@ class FrameFile(object):
         Raises:
             ValueError: Fiber number is out of the valid range for this spectrograph.
         """
-        offset = fiber - self.num_fibers*(self.index - 1) - 1
+        offset = fiber - self.num_fibers * (self.index - 1) - 1
         if np.any((offset < 0) | (offset >= self.num_fibers)):
             raise ValueError('Fiber number out of range for this spectrograph.')
         return offset


### PR DESCRIPTION
Fixes issue #74 and changes the output format from `bossplot --verbose ...` when using spec files.
