### PR TITLE
Add options to get_valid_data methods

### DIFF
--- a/bin/bossplot
+++ b/bin/bossplot
@@ -390,7 +390,7 @@ def main():
         if save_name == '':
             save_name = plot_label + '.dat'
         # Only save un-masked rows.
-        valid = ~(spectra[0]['wavelength'].mask)
+        valid = ~(spectra[0]['flux'].mask)
         table = astropy.table.Table(spectra[0][valid])
         try:
             table.write(save_name, format='ascii.basic')
@@ -423,9 +423,9 @@ def main():
             left_axis.fill_between(
                 wlen, flux - dflux, flux + dflux, color=plot_color, alpha=0.5)
 
-        num_masked = np.count_nonzero(data.mask)
+        num_masked = np.count_nonzero(flux.mask)
         if args.show_mask and num_masked > 0:
-            bad_pixels = np.where(data.mask)
+            bad_pixels = np.where(flux.mask)
             for x in data.data['wavelength'][bad_pixels]:
                 x_mask.extend([x, x, None])
 

--- a/bossdata/plate.py
+++ b/bossdata/plate.py
@@ -377,7 +377,9 @@ class PlateFile(object):
                 dflux in 1e-17 ergs/s/cm2/Angstrom (or flux and ivar). Wavelength values
                 are strictly increasing and dflux is calculated as ivar**-0.5 for pixels
                 with valid data. Optional fields are wdisp in constant-log10-lambda pixels
-                and sky in 1e-17 ergs/s/cm2/Angstrom.
+                and sky in 1e-17 ergs/s/cm2/Angstrom. The wavelength (or loglam) field is
+                never masked and all other fields are masked when ivar is zero or a
+                pipeline flag is set (and not allowed by ``pixel_quality_mask``).
         """
         offsets = self.get_fiber_offsets(fibers)
         num_fibers = len(offsets)
@@ -442,7 +444,11 @@ class PlateFile(object):
         else:
             mask = bad_pixels
 
-        return numpy.ma.MaskedArray(data, mask=mask)
+        result = numpy.ma.MaskedArray(data, mask=mask)
+        # Wavelength values are always valid.
+        result['loglam' if use_loglam else 'wavelength'].mask = False
+
+        return result
 
 
 class FrameFile(object):
@@ -556,6 +562,9 @@ class FrameFile(object):
                 ergs/s/cm2/Angstrom. Wavelength values are strictly increasing and dflux is
                 calculated as ivar**-0.5 for pixels with valid data. Optional fields are
                 wdisp in constant-log10-lambda pixels and sky in 1e-17 ergs/s/cm2/Angstrom.
+                The wavelength (or loglam) field is never masked and
+                all other fields are masked when ivar is zero or a pipeline flag is set (and
+                not allowed by ``pixel_quality_mask``).
         """
         offsets = self.get_fiber_offsets(fibers)
         num_fibers = len(offsets)
@@ -626,4 +635,8 @@ class FrameFile(object):
         if include_sky:
             data['sky'][:] = self.sky[offsets]
 
-        return numpy.ma.MaskedArray(data, mask=bad_pixels)
+        result = numpy.ma.MaskedArray(data, mask=mask)
+        # Wavelength values are always valid.
+        result['loglam' if use_loglam else 'wavelength'].mask = False
+
+        return result

--- a/bossdata/plate.py
+++ b/bossdata/plate.py
@@ -364,8 +364,8 @@ class PlateFile(object):
                 data.
             use_loglam: Replace ``wavelength`` with ``loglam`` (``log10(wavelength)``) in
                 the returned data.
-            fiducial_grid: Return co-added data using the fiducial wavelength grid defined
-                by :attr:`fiducial_pixel_index_range`.  If False, the returned array uses
+            fiducial_grid: Return co-added data using the :attr:`fiducial wavelength grid
+                <bossdata.spec.fiducial_loglam>`.  If False, the returned array uses
                 the native grid of the SpecFile, which generally trims pixels on both ends
                 that have zero inverse variance.  Set this value True to ensure that all
                 co-added spectra use aligned wavelength grids when this matters.

--- a/bossdata/plate.py
+++ b/bossdata/plate.py
@@ -16,7 +16,7 @@ import astropy.table
 
 import fitsio
 
-from bossdata.spec import Exposures
+from bossdata.spec import Exposures, fiducial_loglam, get_fiducial_pixel_index
 
 
 def get_num_fibers(plate):
@@ -345,7 +345,8 @@ class PlateFile(object):
         return self.masks[offsets]
 
     def get_valid_data(self, fibers, pixel_quality_mask=None,
-                       include_wdisp=False, include_sky=False):
+                       include_wdisp=False, include_sky=False, use_ivar=False,
+                       use_loglam=False, fiducial_grid=False):
         """Get the valid for the specified fibers.
 
         Args:
@@ -359,14 +360,24 @@ class PlateFile(object):
                 for each individual exposure. No mask is applied if this value is None.
             include_wdisp: Include a wavelength dispersion column in the returned data.
             include_sky: Include a sky flux column in the returned data.
+            use_ivar: Replace ``dflux`` with ``ivar`` (inverse variance) in the returned
+                data.
+            use_loglam: Replace ``wavelength`` with ``loglam`` (``log10(wavelength)``) in
+                the returned data.
+            fiducial_grid: Return co-added data using the fiducial wavelength grid defined
+                by :attr:`fiducial_pixel_index_range`.  If False, the returned array uses
+                the native grid of the SpecFile, which generally trims pixels on both ends
+                that have zero inverse variance.  Set this value True to ensure that all
+                co-added spectra use aligned wavelength grids when this matters.
 
         Returns:
             numpy.ma.MaskedArray: Masked array of shape (nfibers,npixels). Pixels with no
                 valid data are included but masked. The record for each pixel has at least
-                the following named fields: wavelength in Angstroms, flux and dflux in 1e-17
-                ergs/s/cm2/Angstrom. Wavelength values are strictly increasing and dflux is
-                calculated as ivar**-0.5 for pixels with valid data. Optional fields are
-                wdisp in constant-log10-lambda pixels and sky in 1e-17 ergs/s/cm2/Angstrom.
+                the following named fields: wavelength in Angstroms (or loglam), flux and
+                dflux in 1e-17 ergs/s/cm2/Angstrom (or flux and ivar). Wavelength values
+                are strictly increasing and dflux is calculated as ivar**-0.5 for pixels
+                with valid data. Optional fields are wdisp in constant-log10-lambda pixels
+                and sky in 1e-17 ergs/s/cm2/Angstrom.
         """
         offsets = self.get_fiber_offsets(fibers)
         num_fibers = len(offsets)
@@ -386,7 +397,17 @@ class PlateFile(object):
             self.wdisp = self.hdulist[4].read()
         if include_sky and self.sky is None:
             self.sky = self.hdulist[6].read()
-        num_pixels = self.flux.shape[1]
+
+        if fiducial_grid:
+            loglam = fiducial_loglam
+            first_index = float(get_fiducial_pixel_index(10.0**self.loglam[0]))
+            if abs(first_index - round(first_index)) > 0.01:
+                raise RuntimeError('Wavelength grid not aligned with fiducial grid.')
+            trimmed = slice(first_index, first_index + pixel_bits.shape[1])
+        else:
+            loglam = self.loglam
+            trimmed = slice(None)
+        num_pixels = len(loglam)
 
         # Identify the pixels with valid data.
         ivar = self.ivar[offsets]
@@ -394,21 +415,34 @@ class PlateFile(object):
         good_pixels = ~bad_pixels
 
         # Create and fill the unmasked structured array of data.
-        dtype = [('wavelength', np.float32), ('flux', np.float32), ('dflux', np.float32)]
+        dtype = [('loglam' if use_loglam else 'wavelength', np.float32),
+                 ('flux', np.float32), ('ivar' if use_ivar else 'dflux', np.float32)]
         if include_wdisp:
             dtype.append(('wdisp', np.float32))
         if include_sky:
             dtype.append(('sky', np.float32))
-        data = np.empty((num_fibers, num_pixels), dtype=dtype)
-        data['wavelength'][:] = np.power(10.0, self.loglam)
-        data['flux'][:] = self.flux[offsets]
-        data['dflux'][:][good_pixels] = 1.0 / np.sqrt(self.ivar[offsets][good_pixels])
+        data = np.zeros((num_fibers, num_pixels), dtype=dtype)
+        if use_loglam:
+            data['loglam'][:] = loglam
+        else:
+            data['wavelength'][:] = np.power(10.0, loglam)
+        data['flux'][:,trimmed] = self.flux[offsets]
+        if use_ivar:
+            data['ivar'][:,trimmed][good_pixels] = self.ivar[offsets][good_pixels]
+        else:
+            data['dflux'][:,trimmed][good_pixels] = 1.0 / np.sqrt(self.ivar[offsets][good_pixels])
         if include_wdisp:
-            data['wdisp'][:] = self.wdisp[offsets]
+            data['wdisp'][:,trimmed] = self.wdisp[offsets]
         if include_sky:
-            data['sky'][:] = self.sky[offsets]
+            data['sky'][:,trimmed] = self.sky[offsets]
 
-        return numpy.ma.MaskedArray(data, mask=bad_pixels)
+        if fiducial_grid:
+            mask = np.ones_like(data, dtype=bool)
+            mask[:,trimmed] = bad_pixels
+        else:
+            mask = bad_pixels
+
+        return numpy.ma.MaskedArray(data, mask=mask)
 
 
 class FrameFile(object):

--- a/bossdata/spec.py
+++ b/bossdata/spec.py
@@ -276,7 +276,9 @@ class SpecFile(object):
                 ergs/s/cm2/Angstrom (or flux and ivar). Wavelength values are strictly
                 increasing and dflux is calculated as ivar**-0.5 for pixels with valid data.
                 Optional fields are wdisp in constant-log10-lambda pixels and sky in 1e-17
-                ergs/s/cm2/Angstrom.
+                ergs/s/cm2/Angstrom. The wavelength (or loglam) field is never masked and
+                all other fields are masked when ivar is zero or a pipeline flag is set (and
+                not allowed by ``pixel_quality_mask``).
 
         Raises:
             ValueError: fiducial grid is not supported for individual exposures.
@@ -341,4 +343,8 @@ class SpecFile(object):
         else:
             mask = bad_pixels
 
-        return numpy.ma.MaskedArray(data, mask=mask)
+        result = numpy.ma.MaskedArray(data, mask=mask)
+        # Wavelength values are always valid.
+        result['loglam' if use_loglam else 'wavelength'].mask = False
+
+        return result

--- a/bossdata/tests/test_spec.py
+++ b/bossdata/tests/test_spec.py
@@ -1,9 +1,16 @@
 # Licensed under a MIT style license - see LICENSE.rst
 
-import pytest
+import numpy as np
 
 from .. import spec
+
 
 def test_pixel_index():
     assert spec.get_fiducial_pixel_index(3500.26) == 0
     assert spec.get_fiducial_pixel_index(3564.51) == 79
+
+
+def test_fiducial_range():
+    assert np.array_equal(
+        spec.get_fiducial_pixel_index(spec.fiducial_wavelengths),
+        np.arange(*spec.fiducial_pixel_index_range))

--- a/bossdata/tests/test_spec.py
+++ b/bossdata/tests/test_spec.py
@@ -1,0 +1,9 @@
+# Licensed under a MIT style license - see LICENSE.rst
+
+import pytest
+
+from .. import spec
+
+def test_pixel_index():
+    assert spec.get_fiducial_pixel_index(3500.26) == 0
+    assert spec.get_fiducial_pixel_index(3564.51) == 79

--- a/bossdata/tests/test_spec.py
+++ b/bossdata/tests/test_spec.py
@@ -5,12 +5,8 @@ import numpy as np
 from .. import spec
 
 
-def test_pixel_index():
-    assert spec.get_fiducial_pixel_index(3500.26) == 0
-    assert spec.get_fiducial_pixel_index(3564.51) == 79
-
-
 def test_fiducial_range():
-    assert np.array_equal(
-        spec.get_fiducial_pixel_index(spec.fiducial_wavelengths),
+    fiducial_grid = np.power(10., spec.fiducial_loglam)
+    assert np.allclose(
+        spec.get_fiducial_pixel_index(fiducial_grid),
         np.arange(*spec.fiducial_pixel_index_range))


### PR DESCRIPTION
This is an update to `get_valid_data` in SpecFile, PlateFile and FrameFile. The new options are:

```
use_ivar: Replace ``dflux`` with ``ivar`` (inverse variance) in the returned
    data.
use_loglam: Replace ``wavelength`` with ``loglam`` (``log10(wavelength)``) in
    the returned data.
fiducial_grid: Return co-added data using the fiducial wavelength grid defined
    by :attr:`fiducial_pixel_index_range`.  If False, the returned array uses
    the native grid of the SpecFile, which generally trims pixels on both ends
    that have zero inverse variance.  Set this value True to ensure that all
    co-added spectra use aligned wavelength grids when this matters.
```

The last option only applies to the coadd of a (non-lite) SpecFile and does not apply at all to a FrameFile.
